### PR TITLE
chore(tool): clean up commitlint configuration

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,19 +1,13 @@
 import { RuleConfigSeverity } from "@commitlint/types";
 
+const scopes = [`actions`, `cmake`, `docs`, `package`, `tool`];
+
 export default {
   extends: ["@commitlint/config-conventional"],
   defaultIgnores: true,
   rules: {
-    "subject-case": [
-      RuleConfigSeverity.Error,
-      `always`,
-      [`sentence-case`, `lower-case`],
-    ],
+    "subject-case": [RuleConfigSeverity.Error, `always`, [`lower-case`]],
     "scope-case": [RuleConfigSeverity.Error, `always`, [`kebab-case`]],
-    "scope-enum": [
-      RuleConfigSeverity.Error,
-      `always`,
-      [`actions`, `github`, `cmake`, `docs`, `renovate`, `tools`, `package`],
-    ],
+    "scope-enum": [RuleConfigSeverity.Error, `always`, scopes],
   },
 };


### PR DESCRIPTION
This reverts the brief "sentence" case that was a result of a bad renovate configuration setting.

This also simplifies our scopes. I'm fine with not having a "universal" set of scopes for now anyhow.
