### PR TITLE
ci(actions): improve actions to skip unnecessary steps safely

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,3 @@
-# TODO: Make some jobs run only on specific file changes
 # TODO: make this a workflow_call so it is used as a building block?
 name: Lint
 on:
@@ -22,13 +21,23 @@ jobs:
         with:
           typos_flags: --config ${{github.workspace}}/.github/typos.toml
           reporter: github-pr-review
+  skip-renovate:
+    runs-on: ubuntu-latest
+    name: Skip Duplicate Actions (Renovate)
+    outputs:
+      should-skip: ${{steps.sda.outputs.should_skip}}
+    steps:
+      - uses: fkirc/skip-duplicate-actions@v5
+        id: sda
+        with:
+          paths: '[".github/renovate.json"]'
   renovate:
     runs-on: ubuntu-latest
     name: Renovate
+    needs: skip-renovate
+    if: needs.skip-renovate.outputs.should-skip != 'true'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
-        with:
-          cache-dependency-path: "**/package-lock.json"
-          cache: npm
       - run: npm exec --package=renovate -- renovate-config-validator
+

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,14 +3,25 @@ on:
   pull_request:
     types: [opened, synchronize, edited]
 jobs:
+  skip:
+    name: Skip Duplicate Actions
+    runs-on: ubuntu-latest
+    outputs:
+      should-skip: ${{steps.sda.outputs.should_skip}}
+    steps:
+      - uses: fkirc/skip-duplicate-actions@v5
+        id: sda
   title:
     runs-on: ubuntu-latest
     name: Check PR Title
+    needs: skip
+    if: needs.skip.outputs.should-skip != 'true'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
         with:
-          cache-dependency-path: "**/package-lock.json"
+          check-latest: true
+          node-version: 'lts/*'
           cache: npm
       - run: npm ci
       - run: jq -r '.pull_request.title' "${GITHUB_EVENT_PATH}" > PR_TITLE
@@ -32,3 +43,4 @@ jobs:
   #   steps:
   #     - uses: actions/checkout@v4
   #     - uses: vmactions/${{ matrix.os.name }}-vm@v1
+


### PR DESCRIPTION
This makes sure renovate's config isn't validated unless we change it.

We also don't run the more expensive commitlint step unless the PR title is
changed. At least in theory...

This also improves caching
