### PR TITLE
fix(cmake)!: automatic component and target discovery fixed

### DIFF
--- a/internal/package.cmake
+++ b/internal/package.cmake
@@ -109,7 +109,11 @@ function (ixm::package::check)
   cmake_language(CALL 🈯::ixm::package::prefix)
   unset(found)
 
+  # We clean up the components *here* as it's quicker to do rather than "every
+  # time we might append"
   get_property(components GLOBAL PROPERTY ${prefix}::components)
+  list(REMOVE_DUPLICATES components)
+  set_property(GLOBAL PROPERTY ${prefix}::components ${components})
 
   foreach (component IN LISTS components)
     cmake_language(CALL 🈯::ixm::package::component)
@@ -130,6 +134,9 @@ function (ixm::package::check)
     HANDLE_VERSION_RANGE
     HANDLE_COMPONENTS
     NAME_MISMATCHED)
+
+  cmake_language(CALL ixm::package::import)
+
   return(PROPAGATE ${CMAKE_FIND_PACKAGE_NAME}_FOUND ${found})
 endfunction()
 
@@ -151,6 +158,10 @@ function (ixm::package::import)
         TARGET ${target})
     endforeach()
   endforeach()
+  get_property(targets GLOBAL PROPERTY ${prefix}::targets)
+  foreach (target IN LISTS targets)
+    cmake_language(CALL ixm::package::target TARGET ${target})
+  endforeach()
 endfunction()
 
 function (ixm::package::target)
@@ -158,14 +169,13 @@ function (ixm::package::target)
   cmake_language(CALL 🈯::ixm::requires TARGET)
   cmake_language(CALL 🈯::ixm::package::assert)
   cmake_language(CALL 🈯::ixm::package::prefix)
-  set(prefix ${prefix}::${ARG_TARGET})
   # Each variable contains a variable name, thus we need to "expand" it out.
-  get_property(version GLOBAL PROPERTY ${prefix}::version)
-  get_property(program GLOBAL PROPERTY ${prefix}::program)
-  get_property(library GLOBAL PROPERTY ${prefix}::library)
-  get_property(include GLOBAL PROPERTY ${prefix}::include)
-  get_property(compile GLOBAL PROPERTY ${prefix}::options::compile)
-  get_property(link GLOBAL PROPERTY ${prefix}::options::link)
+  get_property(version GLOBAL PROPERTY ${prefix}::{${ARG_TARGET}}::version)
+  get_property(program GLOBAL PROPERTY ${prefix}::{${ARG_TARGET}}::program)
+  get_property(library GLOBAL PROPERTY ${prefix}::{${ARG_TARGET}}::library)
+  get_property(include GLOBAL PROPERTY ${prefix}::{${ARG_TARGET}}::include)
+  get_property(compile GLOBAL PROPERTY ${prefix}::{${ARG_TARGET}}::options::compile)
+  get_property(link GLOBAL PROPERTY ${prefix}::{${ARG_TARGET}}::options::link)
   if (program AND library)
     string(CONFIGURE [[
       PACKAGE: @CMAKE_FIND_PACKAGE_NAME@
@@ -178,7 +188,7 @@ function (ixm::package::target)
 
   # Targets can only have ONE location, so appending to a list and then
   # removing empty items is ideal
-  set(location "${${program}}" "${${library}}")
+  set(location "${program}" "${library}")
   list(REMOVE_ITEM location "")
   set(command add_library)
   set(arguments UNKNOWN)
@@ -188,11 +198,12 @@ function (ixm::package::target)
     set(arguments)
   endif()
 
+  # If there's no location, then it's an INTERFACE library
   if (NOT location)
     set(arguments INTERFACE)
   endif()
 
-  cmake_language(CALL ${command} ${arguments} IMPORTED)
+  cmake_language(CALL ${command} ${ARG_TARGET} ${arguments} IMPORTED)
   # IMPORTED targets can have any properties set, so it doesn't really matter
   # if we add include directories to executables.
   target_include_directories(${target} INTERFACE ${${include}})
@@ -208,8 +219,6 @@ function (ixm::package::target)
         VERSION "${version}"
     )
   endif()
-
-
 endfunction()
 
 #[[ Wrapper around set_package_properties to make it easier to work with ]]

--- a/modules/FindFreeBSD.cmake
+++ b/modules/FindFreeBSD.cmake
@@ -35,7 +35,7 @@ set(FreeBSD_PMC_FOUND ${FreeBSD_PerformanceCounters_FOUND})
 set(FreeBSD_VGL_FOUND ${FreeBSD_VideoGraphics_FOUND})
 
 cmake_language(CALL ixm::package::check)
-cmake_language(CALL ixm::package::import)
+
 cmake_language(CALL ixm::package::properties
   DESCRIPTION "FreeBSD C libraries"
   URL "https://man.freebsd.org/cgi/man.cgi?intro(3)")

--- a/modules/FindLinux.cmake
+++ b/modules/FindLinux.cmake
@@ -10,6 +10,6 @@ cmake_language(CALL ixm::find::library COMPONENT PAM NAMES pam)
 cmake_language(CALL ixm::find::library COMPONENT Math NAMES m)
 
 cmake_language(CALL ixm::package::check)
-cmake_language(CALL ixm::package::import)
+
 cmake_language(CALL ixm::package::properties
   DESCRIPTION "The Linux Standard Base Libraries")

--- a/modules/FindNetBSD.cmake
+++ b/modules/FindNetBSD.cmake
@@ -32,7 +32,7 @@ cmake_language(CALL ixm::find::library COMPONENT Wrap NAMES wrap FILE tcpd.h)
 cmake_language(CALL ixm::find::library COMPONENT Utilities NAMES util FILE util.h)
 
 cmake_language(CALL ixm::package::check)
-cmake_language(CALL ixm::package::import)
+
 cmake_language(CALL ixm::package::properties
   DESCRIPTION "NetBSD C Libraries"
   URL "https://man.netbsd.org/intro.3")

--- a/modules/FindOpenBSD.cmake
+++ b/modules/FindOpenBSD.cmake
@@ -38,7 +38,7 @@ cmake_language(CALL ixm::find::library COMPONENT TLS NAMES tls HEADER tls.h)
 cmake_language(CALL ixm::find::library COMPONENT HID NAMES usbhid HEADER usbhid.h)
 
 cmake_language(CALL ixm::package::check)
-cmake_language(CALL ixm::package::import)
+
 cmake_language(CALL ixm::package::properties
   DESCRIPTION "OpenBSD C Libraries"
   URL "https://man.openbsd.org/intro.3")

--- a/modules/FindWindows.cmake
+++ b/modules/FindWindows.cmake
@@ -45,7 +45,7 @@ cmake_language(CALL ixm::find::library COMPONENT Shell NAMES shlwapi HEADER shlw
 cmake_language(CALL ixm::find::library COMPONENT Sockets NAME Ws2_32 HEADER ws2tcpip.h)
 
 cmake_language(CALL ixm::package::check)
-cmake_language(CALL ixm::package::import)
+
 cmake_language(CALL ixm::package::properties
   DESCRIPTION "Win32 API Libraries"
   URL "https://learn.microsoft.com/en-us/windows/win32/api/")

--- a/modules/Findccache.cmake
+++ b/modules/Findccache.cmake
@@ -1,11 +1,5 @@
-cmake_language(CALL ixm::find::program
-  NAMES ccache
-  DESCRIPTION "Path to ccache executable"
-  VERSION
-    OPTION --print-version)
-
+cmake_language(CALL ixm::find::program VERSION OPTION --print-version)
 cmake_language(CALL ixm::package::check)
-cmake_language(CALL ixm::package::import)
 cmake_language(CALL ixm::package::properties
   DESCRIPTION "A fast C/C++ compiler cache"
   URL "https://ccache.dev")

--- a/modules/Findclang-tidy.cmake
+++ b/modules/Findclang-tidy.cmake
@@ -1,10 +1,12 @@
 cmake_language(CALL ixm::find::program
+  OUTPUT_VARIABLE ${CMAKE_FIND_PACKAGE_NAME}_EXECUTABLE
+  VERSION
   NAMES clang-tidy
-  DESCRIPTION "Path to clang-tidy executable"
-  VERSION)
+  PACKAGE
+    TARGET clang::tidy
+)
 
 cmake_language(CALL ixm::package::check)
-cmake_language(CALL ixm::package::import)
 cmake_language(CALL ixm::package::properties
   DESCRIPTION "Clang based C++ linter tool."
   URL "https://clang.llvm.org/extra/clang-tidy")

--- a/modules/Findsccache.cmake
+++ b/modules/Findsccache.cmake
@@ -1,7 +1,5 @@
-cmake_language(CALL ixm::package::program NAMES sccache VERSION)
-
+cmake_language(CALL ixm::package::program VERSION)
 cmake_language(CALL ixm::package::check)
-cmake_language(CALL ixm::package::import)
 cmake_language(CALL ixm::package::properties
   DESCRIPTION "ccache with cloud storage"
   URL "https://github.com/mozilla/sccache")


### PR DESCRIPTION
This change is breaking, as it changes the internal (though *not yet documented*) properties used to track discovered components and targets. We also properly import targets for packages *without* components. That code was never implemented. The reason is simply "I Forgor 💀", however there is very little to be done on the matter.

It also now makes it so that `ixm::package::check` *does* perform the call to `ixm::package::import` as documented.

Furthermore, we now have a default value for `NAMES` for `ixm::find::*` commands used for simple packages that only have a single executable or name.

We also now automatically set the `DESCRIPTION` parameter and it is no longer a required one for simple calls.

This PR also fixes the `find_package(clang-tidy)` module, as it was never finding any targets.

Lastly, we organized the `internal/find.cmake` file slightly, though it is still quite a large file.
