### PR TITLE
fix(cmake): properly disable unnecessary targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,12 @@ block (SCOPE_FOR VARIABLES) # Setting global variables
   set(CMAKE_DISABLE_SOURCE_CHANGES YES CACHE BOOL "")
 endblock()
 
+block (SCOPE_FOR VARIABLES)
+  message(TRACE "Setting default properties")
+  set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMake")
+  set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED YES) # Removes CDash Targets
+endblock()
+
 block (SCOPE_FOR VARIABLES) # Setting default CMake policies
   message(TRACE "Setting default CMake policies")
   if (NOT 🈯::ixm::${CMAKE_VERSION}::policies)

--- a/internal/protobuf.cmake
+++ b/internal/protobuf.cmake
@@ -1,7 +1,6 @@
 include_guard(GLOBAL)
 
 # This is a temporary file until we can move this into the specific module.
-message(TRACE "Setting default properties")
 block (SCOPE_FOR VARIABLES)
   set_property(GLOBAL PROPERTY 🈯::ixm::protobuf::objc::source .pbobjc.m)
   set_property(GLOBAL PROPERTY 🈯::ixm::protobuf::objc::header .pbobjc.h)
@@ -12,9 +11,6 @@ block (SCOPE_FOR VARIABLES)
   set_property(GLOBAL PROPERTY 🈯::ixm::grpc::objc::header .pbrpc.h)
   set_property(GLOBAL PROPERTY 🈯::ixm::grpc::cxx::source .grpc.pb.cc)
   set_property(GLOBAL PROPERTY 🈯::ixm::grpc::cxx::header .grpc.pb.h)
-
-  set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMake")
-  set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED YES) # Removes CDash Targets
 endblock()
 
 message(TRACE "Defining custom protobuf properties")


### PR DESCRIPTION
One of the features IXM is purportedly supposed to do is disable the various CDash targets. Due to a cleanup prior to the repository being made available, the actual properties to set this were in the wrong file.

This PR rectifies this, and also places predefined targets into a CMake folder.
