### PR TITLE
fix(cmake): fix automatic package target import

### DIFF
--- a/internal/package.cmake
+++ b/internal/package.cmake
@@ -206,9 +206,9 @@ function (ixm::package::target)
   cmake_language(CALL ${command} ${ARG_TARGET} ${arguments} IMPORTED)
   # IMPORTED targets can have any properties set, so it doesn't really matter
   # if we add include directories to executables.
-  target_include_directories(${target} INTERFACE ${${include}})
-  target_compile_options(${target} INTERFACE ${${compile}})
-  target_link_options(${target} INTERFACE ${${link}})
+  target_include_directories(${target} INTERFACE ${include})
+  target_compile_options(${target} INTERFACE ${compile})
+  target_link_options(${target} INTERFACE ${link})
 
   # INTERFACE libraries don't like having non INTERFACE properties set, after
   # all.


### PR DESCRIPTION
Older code would list cache variables and not values. This has been fixed to just use the values found in a given property for compile, link, and include values.
