### PR TITLE
feat(cmake)!: improve code coverage module

### DIFF
--- a/internal/package.cmake
+++ b/internal/package.cmake
@@ -206,9 +206,9 @@ function (ixm::package::target)
   cmake_language(CALL ${command} ${ARG_TARGET} ${arguments} IMPORTED)
   # IMPORTED targets can have any properties set, so it doesn't really matter
   # if we add include directories to executables.
-  target_include_directories(${target} INTERFACE ${${include}})
-  target_compile_options(${target} INTERFACE ${${compile}})
-  target_link_options(${target} INTERFACE ${${link}})
+  target_include_directories(${target} INTERFACE ${include})
+  target_compile_options(${target} INTERFACE ${compile})
+  target_link_options(${target} INTERFACE ${link})
 
   # INTERFACE libraries don't like having non INTERFACE properties set, after
   # all.

--- a/modules/FindCoverage.cmake
+++ b/modules/FindCoverage.cmake
@@ -1,5 +1,34 @@
 if ("GNU" IN_LIST ${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS)
   message(WARNING "GNU code coverage is not currently a supported component for Coverage at this time.")
+  cmake_language(CALL ixm::find::program
+    NAMES gcov
+    PACKAGE
+      COMPONENT GNU
+      TARGET Tool)
+  cmake_language(CALL ixm::check::option::compile CXX --coverage
+    OUTPUT_VARIABLE ${CMAKE_FIND_PACKAGE_NAME}_GNU_COMPILE_OPTIONS
+    LINK_OPTIONS --coverage
+    QUIET)
+  if (${CMAKE_FIND_PACKAGE_NAME}_GNU_COMPILE_OPTIONS)
+    set(${CMAKE_FIND_PACKAGE_NAME}_GNU_COMPILE_FLAGS "--coverage")
+  endif()
+  block (SCOPE_FOR VARIABLES)
+    set(target ${CMAKE_FIND_PACKAGE_NAME}::GNU)
+    set(prefix ${target}:{${target}})
+    string(CONCAT abs.path $<AND:
+      $<BOOL:$<TARGET_PROPERTY:GNU_ABSOLUTE_PATHS>>,
+      $<CXX_COMPILER_ID:GNU>
+    >)
+
+    set_property(GLOBAL APPEND PROPERTY ${target}::variables
+      ${CMAKE_FIND_PACKAGE_NAME}_GNU_COMPILE_FLAGS)
+    set_property(GLOBAL APPEND PROPERTY ${target}::targets ${target})
+    set_property(GLOBAL APPEND PROPERTY ${prefix}::options::compile
+        $<$<CXX_COMPILER_ID:AppleClang,Clang,GNU>:--coverage>
+        $<${abs.path}:-fprofile-abs-path>)
+    set_property(GLOBAL APPEND PROPERTY ${prefix}::options::link
+        $<$<CXX_COMPILER_ID:AppleClang,Clang,GNU>:--coverage>)
+  endblock()
 endif()
 
 if ("LLVM" IN_LIST ${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS)
@@ -38,55 +67,57 @@ if ("LLVM" IN_LIST ${CMAKE_FIND_PACKAGE_NAME}_FIND_COMPONENTS)
   if (${CMAKE_FIND_PACKAGE_NAME}_LLVM_COMPILE_OPTIONS)
     set(${CMAKE_FIND_PACKAGE_NAME}_LLVM_COMPILE_FLAGS "-fprofile-instr-generate")
   endif()
-  set_property(GLOBAL APPEND
-    PROPERTY
-      ${CMAKE_FIND_PACKAGE_NAME}::LLVM::variables
+  # This is where we do manual bookkeeping for the automatic component
+  # discovery system, since we're naming a target *after* the component itself
+  # for a library we never *technically found*
+  block (SCOPE_FOR VARIABLES)
+    set(target ${CMAKE_FIND_PACKAGE_NAME}::LLVM)
+    set(prefix ${target}::{${target}})
+    string(CONCAT mcdc $<AND:
+      $<CXX_COMPILER_ID:AppleClang,Clang>,
+      $<BOOL:
+        $<GENEX_EVAL:$<TARGET_PROPERTY:LLVM_MCDC>>
+      >
+    >)
+    string(CONCAT coverage-prefix-map $<JOIN:
+      $<GENEX_EVAL:$<TARGET_PROPERTY:LLVM_COVERAGE_PREFIX_MAP>>,
+      -fcoverage-prefix-map=
+    >)
+    string(CONCAT coverage-prefix-maps $<
+      $<BOOL:$<TARGET_PROPERTY:LLVM_COVERAGE_PREFIX_MAP>>:
+      -fcoverage-prefix-map=${coverage-prefix-map}
+    >)
+    string(CONCAT profile.file $<
+      $<BOOL:$<TARGET_PROPERTY:LLVM_PROFILE_FILENAME>>:
+      =$<GENEX_EVAL:$<TARGET_PROPERTY:LLVM_PROFILE_FILENAME>>
+    >)
+
+    set_property(GLOBAL APPEND PROPERTY ${target}::variables
       ${CMAKE_FIND_PACKAGE_NAME}_LLVM_COMPILE_FLAGS)
+    # NOTE(imuerte): I'm proud of myself for making this work, but also
+    # bewildered at myself.
+    set_property(GLOBAL APPEND PROPERTY ${target}::targets ${target})
+    set_property(GLOBAL APPEND PROPERTY ${prefix}::options::compile
+      $<$<CXX_COMPILER_ID:AppleClang,Clang>:-fprofile-instr-generate${profile.file}>
+      $<$<CXX_COMPILER_ID:AppleClang,Clang>:-fcoverage-mapping>
+      $<${mcdc}:-fcoverage-mcdc>
+      ${coverage-prefix-maps})
+    set_property(GLOBAL APPEND PROPERTY ${prefix}::options::link
+      $<$<CXX_COMPILER_ID:AppleClang,Clang>:-fprofile-instr-generate${profile.file}>)
+  endblock()
 endif()
 
 cmake_language(CALL ixm::package::check)
 cmake_language(CALL ixm::package::properties
   DESCRIPTION "Code Coverage Support")
 
-if (${CMAKE_FIND_PACKAGE_NAME}_LLVM_FOUND)
-  if (NOT TARGET ${CMAKE_FIND_PACKAGE_NAME}::LLVM)
-    block(SCOPE_FOR VARIABLES)
-      string(CONCAT mcdc $<AND:
-        $<CXX_COMPILER_ID:AppleClang,Clang>,
-        $<BOOL:
-          $<GENEX_EVAL:$<TARGET_PROPERTY:LLVM_MCDC>>
-        >
-      >)
-      string(CONCAT coverage-prefix-map $<JOIN:
-        $<GENEX_EVAL:$<TARGET_PROPERTY:LLVM_COVERAGE_PREFIX_MAP>>,
-        -fcoverage-prefix-map=
-      >)
-      string(CONCAT coverage-prefix-maps $<
-        $<BOOL:$<TARGET_PROPERTY:LLVM_COVERAGE_PREFIX_MAP>>:
-        -fcoverage-prefix-map=${coverage-prefix-map}
-      >)
-      string(CONCAT profile.file $<
-        $<BOOL:$<TARGET_PROPERTY:LLVM_PROFILE_FILENAME>>:
-        =$<GENEX_EVAL:$<TARGET_PROPERTY:LLVM_PROFILE_FILENAME>>
-      >)
-      set(target ${CMAKE_FIND_PACKAGE_NAME}::LLVM)
-      add_library(${target} INTERFACE IMPORTED)
-      target_compile_options(${target}
-        INTERFACE
-          $<$<CXX_COMPILER_ID:AppleClang,Clang>:-fprofile-instr-generate${profile.file}>
-          $<$<CXX_COMPILER_ID:AppleClang,Clang>:-fcoverage-mapping>
-          $<${mcdc}:-fcoverage-mcdc>
-          ${coverage-prefix-maps})
-      target_link_options(${target}
-        INTERFACE
-          $<$<CXX_COMPILER_ID:AppleClang,Clang>:-fprofile-instr-generate${profile.file}>)
-    endblock()
-  endif()
-endif()
-
 # Setting a default value
 set(IXM_LLVM_COVERAGE_PREFIX_MAP $<TARGET_PROPERTY:SOURCE_DIR>=.
   CACHE STRING "Default LLVM Coverage prefix map path")
+
+define_property(TARGET
+  PROPERTY GNU_ABSOLUTE_PATHS INHERITED
+  BRIEF_DOCS "Create absolute paths in the .gcno files")
 
 define_property(TARGET
   PROPERTY
@@ -133,6 +164,22 @@ define_property(TARGET
   BRIEF_DOCS
     "Equal to setting LLVM_PROFILE_FILE environment variable when adding a test")
 
+#[[Add a coverage target (to generate and then merge all code coverage data]]
+function (add_coverage name)
+  cmake_language(CALL ixm::unimplemented)
+  cmake_parse_arguments(ARG "LLVM;GNU" "" "" ${ARGN})
+  if (ARG_LLVM AND ARG_GNU)
+    message(FATAL_ERROR "Coverage targets may only have of: LLVM, GNU")
+  endif()
+endfunction()
+
+#[[
+Adds all the steps necessary to generate gcov data files.
+#]]
+function (add_gnu_coverage name)
+  cmake_language(CALL ixm::unimplemented)
+endfunction()
+
 #[============================================================================[
 Creates all the steps necessary to generate an lcov or json coverage report
 file
@@ -144,6 +191,8 @@ function (add_llvm_coverage name)
   cmake_language(CALL 🈯::ixm::default ARG_FORMAT lcov)
   # Can't really remember why there's a ARG_GITHUB. Probably for
   # uploading/writing to a step summary automatically?
+  # Might be as a "step" output, so it can be copied or uploaded to something
+  # like codecov.io
   cmake_language(CALL 🈯::ixm::default ARG_GITHUB "${name}")
   set(ignore.filename.regex $<GENEX_EVAL:$<TARGET_PROPERTY:${name},LLVM_IGNORE_FILENAME_REGEX>>)
   set(test.executables $<GENEX_EVAL:$<TARGET_PROPERTY:${name},LLVM_TEST_EXECUTABLES>>)


### PR DESCRIPTION
This PR brings gcov support and the GNU component to `find_package(Coverage)`. Of note, this is a breaking change as the `add_llvm_coverage` command will most likely go away after this is merged.
