### PR TITLE
fix(docs): improve light theme contrast for code blocks

### DIFF
--- a/.vitepress/ixm/theme.js
+++ b/.vitepress/ixm/theme.js
@@ -55,13 +55,14 @@ class Palette {
 
   static light = {
     foreground: "#25292e",
+    code: "#f5f7f9",
 
     blue: ["#0f8fff", "#368cf9"],
     coral: ["#f25f3a", "#d43511"],
     red: ["#d5232c", "#df0c24"],
 
     cyan: "#00d0fa",
-    green: "#54d961",
+    green: "#3ca048",
     grey: "#818b98",
     indigo: "#7a82f0",
     lemon: "#d8bd0e",
@@ -80,6 +81,7 @@ class Light {
   type = "light";
   colors = {
     "editor.foreground": Palette.light.foreground,
+    "editor.background": Palette.light.code,
   };
   tokenColors = [
     new Token({ scopes: Scopes.COMMENT, color: Palette.light.grey }),

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -56,7 +56,7 @@ code span {
 }
 
 .vp-doc div[class*="language-"] {
-  --vp-code-block-bg: #f9f6fc;
+  --vp-code-block-bg: #f5f7f9;
 }
 
 span.ixm-green {


### PR DESCRIPTION
Hello from Bluesky 👋 

This PR changes the light color scheme to improve the contrast/readability (which is, admittedly subjective to a degree). It does so by changing the color of numbers to a darker shade (while still keeping it distinct from the other green-ish items); and changing the background color of code blocks to a less saturated color. The latter change affects all kinds of tokens (for the better, I hope). The background does lose its very light pinkish tone (which is a shame), but the color scheme keeps its overall character and still looks like natural part of the site.

## Before

Code block:

![a screenshot showing the 'before' state of the light color scheme, focusing on a code block.](https://github.com/user-attachments/assets/8e5b0941-f35f-4c25-941d-041b934d05c0)

Overall:

<img width="1135" alt="a screenshot showing the 'before' state of the light color scheme, focusing on the entire site in a zoomed out view." src="https://github.com/user-attachments/assets/e5c3c56c-98a7-4580-8fa5-24fa610519c3" />

## After

Code block:

![a screenshot showing the 'after' state of the light color scheme, focusing on a code block.](https://github.com/user-attachments/assets/386be469-d93a-49fc-83bd-cf6da7933832)

Overall: 

<img width="1155" alt="A screenshot showing the 'before' state of the light color scheme, focusing on the entire site in a zoomed out view." src="https://github.com/user-attachments/assets/3ac37896-6d2b-4886-885c-c20d35600fbe" />

