### PR TITLE
refactor(cmake)!: set `IXM_FILES_DIR` to `${CMAKE_BINARY_DIR}/.ixm`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(CMakePrintHelpers)
 
 block (SCOPE_FOR VARIABLES) # Setting internal variables
   message(TRACE "Setting internal variables")
-  set(IXM_FILES_DIR "${CMAKE_BINARY_DIR}/IXMFiles" CACHE INTERNAL "")
+  set(IXM_FILES_DIR "${CMAKE_BINARY_DIR}/.ixm" CACHE INTERNAL "")
   set(IXM_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "IXM Root Directory")
 endblock()
 


### PR DESCRIPTION
This is technically a backport decision from #21. CMake is starting to place "newer" features into `.cmake` instead of `CMakeFiles`, so it stands that IXM should do the same.
