### PR TITLE
chore(config): reduce commitlint and renovate details

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,8 +2,7 @@
   "extends": [
     "config:recommended",
     "npm:unpublishSafe",
-    ":gitSignOff",
-    ":semanticCommitScope(package)"
+    ":gitSignOff"
   ],
   "schedule": ["after 12pm on sunday"],
   "labels": ["renovate:dependencies"],

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,13 +1,10 @@
 import { RuleConfigSeverity } from "@commitlint/types";
 
-const scopes = [`actions`, `cmake`, `docs`, `package`, `tool`];
-
 export default {
   extends: ["@commitlint/config-conventional"],
   defaultIgnores: true,
   rules: {
     "subject-case": [RuleConfigSeverity.Error, `always`, [`lower-case`]],
     "scope-case": [RuleConfigSeverity.Error, `always`, [`kebab-case`]],
-    "scope-enum": [RuleConfigSeverity.Error, `always`, scopes],
   },
 };


### PR DESCRIPTION
It's easier to just rely on the `type-enum` and change the scope in the title of PRs from myself or others than to deal with it as a hard error requirement. This also means we'll go back to `chore(deps)` but I'm fine with that. We don't want those to show up in our changelog once we start using `git-cliff` anyhow.
