### PR TITLE
ci(actions): build documentation when a PR is opened

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,18 @@
+name: Documentation
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths: [docs/**]
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    name: Build Documentation
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
+        with:
+          check-latest: true
+          node-version: 'lts/*'
+          cache: npm
+      - run: npm ci
+      - run: npm run docs:build


### PR DESCRIPTION
After the recent deployment failure, checking to make sure documentation at least builds if any file under `docs/` is built is worth the time we run the task for. Currently using the builtin `paths` argument, but might switch to the skip-duplicate-actions workflow so that we can mark this workflow as required.

Additionally, we're not doing anything with the output, we just want to make sure there aren't any build errors from vitepress at this time. If we move to starlight in the future, we'll most likely keep this same approach/workflow.
