### PR TITLE
feat(find): add JACK2 find_package module

### DIFF
--- a/modules/FindJACK2.cmake
+++ b/modules/FindJACK2.cmake
@@ -1,0 +1,32 @@
+cmake_language(CALL ixm::find::program
+  VERSION
+  NAMES jackd
+  PACKAGE
+    COMPONENT Daemon)
+
+cmake_language(CALL ixm::find::library
+  NAMES
+    jack64)
+
+cmake_language(CALL ixm::find::header
+  NAMES
+    jack/jack.h)
+
+cmake_language(CALL ixm::find::library
+  NAMES
+    jacknet64
+  PATHS
+    ENV ProgramFiles
+  PACKAGE
+    COMPONENT Net)
+
+cmake_language(CALL ixm::find::library
+  NAMES
+    jackserver64
+  PACKAGE
+    COMPONENT Server)
+
+cmake_language(CALL ixm::package::check)
+cmake_language(CALL ixm::package::properties
+  DESCRIPTION "JACK Audio Connection Kit"
+  URL "https://jackaudio.org/")

--- a/runtime/find.cmake
+++ b/runtime/find.cmake
@@ -94,7 +94,7 @@ endfunction()
 # @description This function is *typically* used for finding header files. As a
 # result, when the function is called inside of a `find_package(MODULE)` file,
 # it will perform bookkeeping for automatic component discovery and creating
-# imported targets *as if the file being searched for will be included via the
+# imported targets *as if* the file being searched for will be included via the
 # C/C++ preprocessor.
 # TODO: This function needs to be broken up into ::header and ::path. We want
 # to accept more than just headers for searches
@@ -104,7 +104,7 @@ function (ixm::find::header)
   ixm_fallback(ARG_OUTPUT_VARIABLE ${name}_INCLUDE_DIR)
 
   find_path(${ARG_OUTPUT_VARIABLE} NAMES ${ARG_NAMES} ${ARG_UNPARSED_ARGUMENTS})
-  cmake_language(CALL 🈯::ixm::log)
+  cmake_language(CALL 🈯::ixm::find::log)
   cmake_language(CALL 🈯::ixm::find::properties ${prefix}::{${target}}::include)
 endfunction()
 
@@ -193,7 +193,7 @@ function (🈯::ixm::find::log)
     endif()
     message(CONFIGURE_LOG
       "${call-site}: ${ARG_OUTPUT_VARIABLE}"
-      "= ${${ARG_OUTPUT_VARIABLE}}")
+      "=${${ARG_OUTPUT_VARIABLE}}")
   endif()
 endfunction()
 

--- a/runtime/package.cmake
+++ b/runtime/package.cmake
@@ -149,9 +149,11 @@ function (ixm::package::import)
   set(prefix ${CMAKE_FIND_PACKAGE_NAME})
 
   get_property(components GLOBAL PROPERTY ${prefix}::components)
+  list(REMOVE_DUPLICATES components)
 
   foreach (component IN LISTS components)
     get_property(targets GLOBAL PROPERTY ${prefix}::${component}::targets)
+    list(REMOVE_DUPLICATES targets)
     foreach (target IN LISTS targets)
       cmake_language(CALL ixm::package::target
         COMPONENT ${component}
@@ -159,6 +161,7 @@ function (ixm::package::import)
     endforeach()
   endforeach()
   get_property(targets GLOBAL PROPERTY ${prefix}::targets)
+  list(REMOVE_DUPLICATES targets)
   foreach (target IN LISTS targets)
     cmake_language(CALL ixm::package::target TARGET ${target})
   endforeach()


### PR DESCRIPTION
This PR brings several important fixes in addition to the new feature:

1. Duplicate target and component names are now correctly removed.
2. We now know we'll need a breaking change fix for find::library, as the `HEADER` argument *fails* in all cases where the directory location and package share the same name.
3. Some internal documentation markdown was fixed.

It is unfortunate that the JACK2 interface, library, and packages are so confusing between Windows and Linux. Very little effort has been done to make it clear that the jack2 API is hidden behind packages like `jackd`, which have nothing to do with `libjack-dev`.

Thankfully, it seems we're "one of the first" in this space, as there are effectively *no* FindJACK2.cmake files on github, and the ones that are provide a simplistic API that will not eventually support:

 - Static Library Preferences
 - Finding the jackd Daemon itself (for launching via tests, I assume)
 - Automatic target importing
